### PR TITLE
Add cpan_path to CHECKSUMS to appease modern CPAN clients

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ version 1.16:
 	- this module does not use OODoc for manuals.  Remove that from the
 	  README.md
 	- Sort of packages-list is case-insensitive [Steven Leung]
+	- Add cpan_path to CHECKSUMS file for modern CPAN clients [Jason McCarver]
 
 version 1.15: Sat Jan 13 23:27:38 CET 2018
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,16 +24,17 @@ WriteMakefile
 
  , AUTHOR     => 'Mark Overmeer'
  , PREREQ_PM  =>
-   { Archive::Tar       => 1.00
-   , Archive::Zip       => 0
-   , CPAN::Checksums    => 0
-   , Getopt::Long       => 0
-   , HTTP::Date         => 0
-   , IO::Zlib           => 0
-   , Log::Report        => 0.25
-   , LWP                => 0
-   , Test::More         => 0.82
-   , version            => 0.76
+   { Archive::Tar        => 1.00
+   , Archive::Zip        => 0
+   , CPAN::Checksums     => 0
+   , Getopt::Long        => 0
+   , HTTP::Date          => 0
+   , IO::Zlib            => 0
+   , Log::Report         => 0.25
+   , LWP                 => 0
+   , Test::More          => 0.82
+   , Test::TempDir::Tiny => 0.018
+   , version             => 0.76
    }
  , LICENSE    => 'perl_5'
 

--- a/lib/CPAN/Site/Index.pm
+++ b/lib/CPAN/Site/Index.pm
@@ -42,7 +42,7 @@ sub update_global_cpan($$);
 sub load_file($$);
 sub merge_global_cpan($$$);
 sub create_details($$$$$);
-sub calculate_checksums($);
+sub calculate_checksums($$);
 sub read_details($);
 sub remove_expired_details($$$);
 sub mkdirhier(@);
@@ -122,7 +122,7 @@ sub cpan_index($@)
                  , from => $newlist, to => $details;
     }
 
-    calculate_checksums $distdirs;
+    calculate_checksums $distdirs, catdir($mycpan, 'authors', 'id');
 }
 
 #
@@ -389,13 +389,14 @@ __HEADER
    }
 }
 
-sub calculate_checksums($)
+sub calculate_checksums($$)
 {   my $dirs = shift;
+    my $root = shift;
     trace "updating checksums";
 
     foreach my $dir (keys %$dirs)
     {   trace "summing $dir";
-        CPAN::Checksums::updatedir($dir)
+        CPAN::Checksums::updatedir($dir, $root)
             or warning 'failed calculating checksums in {dir}', dir => $dir;
     }
 }

--- a/t/30cpan_path.t
+++ b/t/30cpan_path.t
@@ -1,0 +1,57 @@
+#!/usr/bin/env perl
+# Verify generated CHECKCUMS has an appropriate 'cpan_path' member
+#-------------------------------------------------------------------------------
+$^W = 0;
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use IO::Zlib ();
+use Test::More tests => 2;
+use Test::TempDir::Tiny;
+use File::Spec::Functions qw(catdir catfile);
+use File::Path qw(make_path);
+use File::Copy;
+
+# use Log::Report 'cpan-site', mode => 'DEBUG';
+
+use_ok('CPAN::Site::Index');
+
+test_cpan_path_generation();
+
+exit;
+
+#-------------------------------------------------------------------------------
+
+sub test_cpan_path_generation {
+    my $distro = 'Distro-With-Multi-Package-Module.tar.gz';
+
+    my $tmpdir = tempdir();
+    $tmpdir && -d $tmpdir or die "Something went horribly wrong!";
+
+    my $mycpan  = catdir($tmpdir, 'site');
+    my $distdir = catdir($mycpan, qw(authors id L LO LOCAL));
+
+    make_path($distdir)
+        or return diag "Failed to create temp directory";
+
+    copy(catdir($Bin, 'test_data', $distro), $distdir)
+        or return diag "Failed to copy distribution to temp directory: $!";
+
+    # XXX: I don't know if there's a way to avoid pulling data from cpan.org in this test or not...
+    CPAN::Site::Index::cpan_index($mycpan, 'https://cpan.org/', lazy => 0, fallback => 0, undefs => 0);
+
+    -r catfile($distdir, "CHECKSUMS")
+        or return diag "No CHECKSUMS file";
+
+    open my $fh, '<', catfile($distdir, "CHECKSUMS")
+        or return diag "Failed to open CHECKSUMS";
+
+    read $fh, my $cksum, -s $fh
+        or return diag "Failed to read CHECKSUMS";
+    close $fh;
+
+    $cksum = eval $cksum
+        or return diag "Failed to eval CHECKSUMS";
+
+    ok ref($cksum) eq 'HASH' && $cksum->{$distro} && ($cksum->{$distro}->{cpan_path}//'') eq 'L/LO/LOCAL';
+}


### PR DESCRIPTION
The CPAN client 'cpan' and possibly others now look for a 'cpan_path'
element in the $cksum hash in the CHECKSUMS file.

See: http://blogs.perl.org/users/neilb/2021/11/addressing-cpan-vulnerabilities-related-to-checksums.html